### PR TITLE
Fix release and whitelist button for getting the correct a href URL

### DIFF
--- a/templates/digestday.mail.tpl
+++ b/templates/digestday.mail.tpl
@@ -16,7 +16,7 @@
 		{if !$recipient}<td>{$mail.to|substrdots:30|escape}</td>{/if}
 		<td>{$mail.subject|substrdots:30|escape}</td>
 		{if $mail.release_url}<td><a href="{$mail.release_url}">Release</a></td>{/if}
-		{if $mail.release_url_whitelist}<td><a href="{$mail.release_url}">Release and whitelist</a></td>{/if}
+		{if $mail.release_url_whitelist}<td><a href="{$mail.release_url_whitelist}">Release and whitelist</a></td>{/if}
 	</tr>
 	{/foreach}
 </table>


### PR DESCRIPTION
The digest mail had a wrong link for the 'release and whitelist' button